### PR TITLE
[DOM-67795] Bump environment name to Domino Standard Environment Py3.10 R4.5

### DIFF
--- a/different_execution_parameters.py
+++ b/different_execution_parameters.py
@@ -13,7 +13,7 @@ def simple_math_workflow(a: int, b: int) -> float:
     add_task = run_domino_job_task(
         flyte_task_name="Add numbers",
         command="python add.py",
-        environment_name="Domino Standard Environment Py3.10 R4.4",
+        environment_name="Domino Standard Environment Py3.10 R4.5",
         hardware_tier_name="Small",
         inputs=[
             Input(name="first_value", type=int, value=a),


### PR DESCRIPTION
# Problem:

https://dominodatalab.testrail.io/index.php?/cases/view/1460143
Test uses R4.4 env and fails

# Solution

Test uses R4.5 env (new since 6.1 and passes)

https://dominodatalab.atlassian.net/browse/DOM-67795