### PR TITLE
[DOM-67895] Add helper script to support e2e test

### DIFF
--- a/generate_and_run_workflow_for_dataset.sh
+++ b/generate_and_run_workflow_for_dataset.sh
@@ -1,2 +1,8 @@
-sed "s/DATASET_ID_TEMPLATE/$1/g" generate_artifacts.py > generate_artifacts_with_dataset_exports.py
+"""
+Helper script to run generate_artifacts.generate_artifacts_with_dataset_exports with the specified dataset.
+The script parses the dataset id from the input dataset URL, and creates a new workflow file with this dataset
+id injected into it via sed.
+"""
+DATASET_ID=$(basename "$1")
+sed "s/DATASET_ID_TEMPLATE/$DATASET_ID/g" generate_artifacts.py > generate_artifacts_with_dataset_exports.py
 pyflyte run --remote generate_artifacts_with_dataset_exports.py generate_artifacts_with_dataset_exports

--- a/generate_and_run_workflow_for_dataset.sh
+++ b/generate_and_run_workflow_for_dataset.sh
@@ -1,0 +1,2 @@
+sed "s/DATASET_ID_TEMPLATE/$1/g" generate_artifacts.py > generate_artifacts_with_dataset_exports.py
+pyflyte run --remote generate_artifacts_with_dataset_exports.py generate_artifacts_with_dataset_exports

--- a/generate_artifacts.py
+++ b/generate_artifacts.py
@@ -55,3 +55,29 @@ def generate_artifacts():
             )
 
     return 
+
+
+@workflow
+def generate_artifacts_with_dataset_exports(): 
+
+    sce_types = DominoJobTask(
+        name="Generate SCE Types",
+        domino_job_config=DominoJobConfig(MainRepoGitRef=GitRef(Type="head"),
+                                          Command="python /mnt/code/scripts/generate-sce-types.py"),
+        inputs={'sdtm_data_path': str},
+        outputs={'pdf': ReportArtifact.File(name="generated.pdf"), 'sas7bdat': DataArtifact.File(name="data.sas7bdat")},
+        use_latest=True
+    )
+
+    sce_types(sdtm_data_path="/mnt/code/artifacts")
+
+    from flytekitplugins.domino.artifact import run_launch_export_artifacts_task, ExportArtifactToDatasetsSpec
+    run_launch_export_artifacts_task([
+        ExportArtifactToDatasetsSpec(
+            artifact=DataArtifact,
+            dataset_id="DATASET_ID_TEMPLATE",
+        ),
+    ])
+
+    return 
+


### PR DESCRIPTION
Add helper script to run generate_artifacts.generate_artifacts_with_dataset_exports with the specified dataset.
The script parses the dataset id from the input dataset URL, and creates a new workflow file with this dataset
id injected into it via sed.

## Context:

To test the programmatic exports feature, we need to run a Flyte workflow with a dataset ID specified in the workflow. For example, we need to simulate a user going into their workflow, and editing it to use some dataset ID.

To simulate this, this PR uses `sed`, which can modify the text of a workflow. Specifically, the PR modifies the workflow to use the specified dataset ID.

https://dominodatalab.atlassian.net/browse/DOM-67895