### PR TITLE
[DOM-67895] Add helper script to support e2e test

### DIFF
--- a/generate_artifacts.py
+++ b/generate_artifacts.py
@@ -72,12 +72,15 @@ def generate_artifacts_with_dataset_exports():
     sce_types(sdtm_data_path="/mnt/code/artifacts")
 
     from flytekitplugins.domino.artifact import run_launch_export_artifacts_task, ExportArtifactToDatasetsSpec
-    run_launch_export_artifacts_task([
-        ExportArtifactToDatasetsSpec(
-            artifact=DataArtifact,
-            dataset_id="DATASET_ID_TEMPLATE",
-        ),
-    ])
+    run_launch_export_artifacts_task(
+        [
+            ExportArtifactToDatasetsSpec(
+                artifact=DataArtifact,
+                dataset_id="DATASET_ID_TEMPLATE",
+            ),
+        ],
+        use_project_defaults_for_omitted=True,
+    )
 
     return 
 


### PR DESCRIPTION
https://github.com/testing-ddl/domino-flows-playground/pull/2 Follow-on

Update `generate_artifacts.generate_artifacts_with_dataset_exports` helper script to add the missing param `use_project_defaults_for_omitted=True`.

## Context:

E2E test for the programmatic exports feature.

https://dominodatalab.atlassian.net/browse/DOM-67895