### PR TITLE
[DOM-72527] Use keyword arguments in the helper run_launch_export_artifacts_task

### DIFF
--- a/generate_artifacts.py
+++ b/generate_artifacts.py
@@ -75,7 +75,7 @@ def generate_artifacts_with_dataset_exports():
 
     from flytekitplugins.domino.artifact import run_launch_export_artifacts_task, ExportArtifactToDatasetsSpec
     run_launch_export_artifacts_task(
-        [
+        spec_list=[
             ExportArtifactToDatasetsSpec(
                 artifact=DataArtifact,
                 dataset_id="DATASET_ID_TEMPLATE",


### PR DESCRIPTION
In https://github.com/cerebrotech/train-flyte-library/commits/main/ we enforced keyword-only arguments for the helper `run_launch_export_artifacts_task`. We should update the flows in this repo to adhere to this convention.

Currently, this workflow calls the helper using positional arguments, which will not be accepted.

The fix is to update the helper call to use keyword arguments.

https://dominodatalab.atlassian.net/browse/DOM-72527