### PR TITLE
[DOM-75010] Refactor workflows to use DominoFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ data_prep_results = run_domino_job(
         Input(name="data_path", type=str, value=data_path)
     ],
     outputs=[
-        Output(name="processed_data", type=FlyteFile)
+        Output(name="processed_data", type=DominoFile)
     ]
 )
 ```
@@ -65,12 +65,12 @@ training_results = run_domino_job(
     environment="Training Environment",
     hardware_tier="Medium",
     inputs=[
-        Input(name="processed_data", type=FlyteFile, value=data_prep_results['processed_data']),
+        Input(name="processed_data", type=DominoFile, value=data_prep_results['processed_data']),
         Input(name="epochs", type=int, value=10),
         Input(name="batch_size", type=int, value=32)
     ],
     outputs=[
-        Output(name="model", type=FlyteFile)
+        Output(name="model", type=DominoFile)
     ]
 )
 ```

--- a/artifacts-example.py
+++ b/artifacts-example.py
@@ -1,6 +1,6 @@
 from flytekitplugins.domino.helpers import DominoJobTask, DominoJobConfig, Input, Output
 from flytekit import workflow, dynamic
-from flytekit.types.file import FlyteFile
+from flytekitplugins.domino.file import DominoFile
 from flytekit.types.directory import FlyteDirectory
 from typing import TypeVar, Optional, List, Dict, Annotated, Tuple, NamedTuple
 from flytekit import Artifact
@@ -43,17 +43,17 @@ ReportArtifact3 = Artifact(name="report3.pdf", partition_keys=["type", "group"])
 
 @workflow
 def artifact_meta(data_path: str) -> Tuple[
-    Annotated[FlyteFile, ReportArtifact(type="report", group="report_foo")], 
-    Annotated[FlyteFile, ReportArtifact2(type="report", group="report_foo")], 
-    Annotated[FlyteFile, ReportArtifact3(type="report", group="report_bar")], 
+    Annotated[DominoFile, ReportArtifact(type="report", group="report_foo")], 
+    Annotated[DominoFile, ReportArtifact2(type="report", group="report_foo")], 
+    Annotated[DominoFile, ReportArtifact3(type="report", group="report_bar")], 
 
     # ideally the definition looks more like this:
-    # Annotated[FlyteFile, Artifact(name="report.pdf", Group=ReportGroup)], 
+    # Annotated[DominoFile, Artifact(name="report.pdf", Group=ReportGroup)], 
     # this could be further simplified in the programming model if we know that these artifacts are only a single file like
     # ArtifactFile(name="report.pdf", Group=ReportGroup)
 
     # normal workflow output with no annotations
-    FlyteFile
+    DominoFile
     ]: 
     """py
     pyflyte run --remote artifacts-example.py artifact_meta --data_path /mnt/data.csv
@@ -70,9 +70,9 @@ def artifact_meta(data_path: str) -> Tuple[
         outputs={
             # NOTE: Flyte normally suppports this -- but notice there are no partitions, which make them useless to Domino
             # this output is consumed by a subsequent task but also marked as an artifact
-            "processed_data": Annotated[FlyteFile, Artifact(name="processed.sas7bdat")],
+            "processed_data": Annotated[DominoFile, Artifact(name="processed.sas7bdat")],
             # no downstream consumers -- simply an artifact output from an intermediate node in the graph
-            "processed_data2": Annotated[FlyteFile, Artifact(name="processed2.sas7bdat")],
+            "processed_data2": Annotated[DominoFile, Artifact(name="processed2.sas7bdat")],
         },
         use_latest=True,
     )(data_path=data_path)
@@ -83,12 +83,12 @@ def artifact_meta(data_path: str) -> Tuple[
             Command="python /mnt/scripts/train-model.py",
         ),
         inputs={
-            "processed_data_in": FlyteFile,
+            "processed_data_in": DominoFile,
             "epochs": int,
             "batch_size": int,
         },
         outputs={
-            "model": FlyteFile,
+            "model": DominoFile,
         },
         use_latest=True,
     )(processed_data_in=data_prep_results.processed_data,epochs=10,batch_size=32)

--- a/cache-wf.py
+++ b/cache-wf.py
@@ -1,11 +1,11 @@
 from flytekitplugins.domino.helpers import Input, Output, run_domino_job_task
 from flytekitplugins.domino.task import DominoJobConfig, DominoJobTask, GitRef, EnvironmentRevisionSpecification, EnvironmentRevisionType, DatasetSnapshot
 from flytekit import workflow
-from flytekit.types.file import FlyteFile
+from flytekitplugins.domino.file import DominoFile
 from flytekit.types.directory import FlyteDirectory
 from typing import TypeVar, NamedTuple
 
-final_outputs = NamedTuple("final_outputs", model=FlyteFile)
+final_outputs = NamedTuple("final_outputs", model=DominoFile)
 
 @workflow
 def training_workflow(data_path: str) -> final_outputs: 
@@ -29,7 +29,7 @@ def training_workflow(data_path: str) -> final_outputs:
             Input(name="data_path", type=str, value=data_path)
         ],
         output_specs=[
-            Output(name="processed_data", type=FlyteFile[TypeVar("csv")])
+            Output(name="processed_data", type=DominoFile[TypeVar("csv")])
         ],
         use_project_defaults_for_omitted=True,
         cache=True,
@@ -43,12 +43,12 @@ def training_workflow(data_path: str) -> final_outputs:
         # environment_name="Domino Standard Environment Py3.10 R4.4",
         hardware_tier_name="Small",
         inputs=[
-            Input(name="processed_data", type=FlyteFile[TypeVar("csv")], value=data_prep_results['processed_data']),
+            Input(name="processed_data", type=DominoFile[TypeVar("csv")], value=data_prep_results['processed_data']),
             Input(name="epochs", type=int, value=10),
             Input(name="batch_size", type=int, value=32)
         ],
         output_specs=[
-            Output(name="model", type=FlyteFile)
+            Output(name="model", type=DominoFile)
         ],
         use_project_defaults_for_omitted=True,
         cache=True,
@@ -79,7 +79,7 @@ def training_workflow_cache(data_path: str) -> final_outputs:
             Input(name="data_path", type=str, value=data_path)
         ],
         output_specs=[
-            Output(name="processed_data", type=FlyteFile[TypeVar("csv")])
+            Output(name="processed_data", type=DominoFile[TypeVar("csv")])
         ],
         use_project_defaults_for_omitted=True,
         cache=True,
@@ -93,12 +93,12 @@ def training_workflow_cache(data_path: str) -> final_outputs:
         main_git_repo_ref=GitRef(Type="commitId", Value="9fc19c5d95e4a21a5b677ce4ac7896d301d831b9"),
         hardware_tier_name="Small",
         inputs=[
-            Input(name="processed_data", type=FlyteFile[TypeVar("csv")], value=data_prep_results['processed_data']),
+            Input(name="processed_data", type=DominoFile[TypeVar("csv")], value=data_prep_results['processed_data']),
             Input(name="epochs", type=int, value=10),
             Input(name="batch_size", type=int, value=32)
         ],
         output_specs=[
-            Output(name="model", type=FlyteFile)
+            Output(name="model", type=DominoFile)
         ],
         use_project_defaults_for_omitted=True,
         cache=True,

--- a/clean.py
+++ b/clean.py
@@ -1,4 +1,4 @@
 import shutil
 
 # pretend to clean data, copying input to output
-shutil.copyfile('/workflow/inputs/data', '/workflow/outputs/data')
+shutil.copyfile('/workflow/inputs/data.csv', '/workflow/outputs/data.csv')

--- a/complex.py
+++ b/complex.py
@@ -11,7 +11,7 @@ from flytekitplugins.domino.artifact import (
     REPORT,
 )
 from flytekit import workflow
-from flytekit.types.file import FlyteFile
+from flytekitplugins.domino.file import DominoFile
 
 TrainingDataReportArtifact = Artifact("Prepped Training Data Report", REPORT)
 ModelAccuracyReportArtifact = Artifact("Model Accuracy Report", REPORT)
@@ -24,7 +24,7 @@ PredictionsArtifact = Artifact("Model Predictions", DATA)
 
 # pyflyte run --remote complex.py complex_artifact_flow --training_data=input_data.csv --test_data=test_data.csv
 @workflow
-def complex_artifact_flow(training_data: FlyteFile[TypeVar("csv")], test_data: FlyteFile[TypeVar("csv")]) -> Tuple[
+def complex_artifact_flow(training_data: DominoFile[TypeVar("csv")], test_data: DominoFile[TypeVar("csv")]) -> Tuple[
     TrainingDataReportArtifact.File(name="Summary Stats", type="txt"),
     TrainingDataReportArtifact.File(name="Data Vizualization", type="jpg"),
     ModelArtifactOne.File(name="Model One", type="pkl"),
@@ -47,12 +47,12 @@ def complex_artifact_flow(training_data: FlyteFile[TypeVar("csv")], test_data: F
         flyte_task_name="Prep data",
         command="prep_data.py",
         inputs=[
-            Input(name="input_data", type=FlyteFile[TypeVar("csv")], value=training_data)
+            Input(name="input_data", type=DominoFile[TypeVar("csv")], value=training_data)
         ],
         output_specs=[
-            Output(name="stats", type=FlyteFile[TypeVar("txt")]),
-            Output(name="viz", type=FlyteFile[TypeVar("jpg")]),
-            Output(name="prepped_data", type=FlyteFile[TypeVar("csv")]),
+            Output(name="stats", type=DominoFile[TypeVar("txt")]),
+            Output(name="viz", type=DominoFile[TypeVar("jpg")]),
+            Output(name="prepped_data", type=DominoFile[TypeVar("csv")]),
         ],
         use_project_defaults_for_omitted=True,
     )
@@ -61,11 +61,11 @@ def complex_artifact_flow(training_data: FlyteFile[TypeVar("csv")], test_data: F
         flyte_task_name="Mask Data",
         command="mask_data.py",
         inputs=[
-            Input(name="input_data", type=FlyteFile[TypeVar("csv")], value=test_data),
+            Input(name="input_data", type=DominoFile[TypeVar("csv")], value=test_data),
         ],
         output_specs=[
-            Output(name="data", type=FlyteFile[TypeVar("csv")]),
-            Output(name="labels", type=FlyteFile[TypeVar("csv")]),
+            Output(name="data", type=DominoFile[TypeVar("csv")]),
+            Output(name="labels", type=DominoFile[TypeVar("csv")]),
         ],
         use_project_defaults_for_omitted=True,
     )
@@ -74,10 +74,10 @@ def complex_artifact_flow(training_data: FlyteFile[TypeVar("csv")], test_data: F
         flyte_task_name="Make Model One",
         command="make_model_one.py",
         inputs=[
-            Input(name="training_data", type=FlyteFile[TypeVar("csv")], value=prepped_training_data)
+            Input(name="training_data", type=DominoFile[TypeVar("csv")], value=prepped_training_data)
         ],
         output_specs=[
-            Output(name="model", type=FlyteFile[TypeVar("pkl")]),
+            Output(name="model", type=DominoFile[TypeVar("pkl")]),
         ],
         use_project_defaults_for_omitted=True,
     )
@@ -85,11 +85,11 @@ def complex_artifact_flow(training_data: FlyteFile[TypeVar("csv")], test_data: F
         flyte_task_name="Classify Model One",
         command="classify_model_one.py",
         inputs=[
-            Input(name="model", type=FlyteFile[TypeVar("pkl")], value=model_one),
-            Input(name="data_points", type=FlyteFile[TypeVar("csv")], value=test_data)
+            Input(name="model", type=DominoFile[TypeVar("pkl")], value=model_one),
+            Input(name="data_points", type=DominoFile[TypeVar("csv")], value=test_data)
         ],
         output_specs=[
-            Output(name="predictions", type=FlyteFile[TypeVar("csv")]),
+            Output(name="predictions", type=DominoFile[TypeVar("csv")]),
         ],
         use_project_defaults_for_omitted=True,
     )
@@ -97,11 +97,11 @@ def complex_artifact_flow(training_data: FlyteFile[TypeVar("csv")], test_data: F
         flyte_task_name="Accuracy Report Model One",
         command="make_accuracy_report.py",
         inputs=[
-            Input(name="predictions", type=FlyteFile[TypeVar("csv")], value=model_one_predictions),
-            Input(name="labels", type=FlyteFile[TypeVar("csv")], value=test_labels),
+            Input(name="predictions", type=DominoFile[TypeVar("csv")], value=model_one_predictions),
+            Input(name="labels", type=DominoFile[TypeVar("csv")], value=test_labels),
         ],
         output_specs=[
-            Output(name="accuracy", type=FlyteFile[TypeVar("pdf")]),
+            Output(name="accuracy", type=DominoFile[TypeVar("pdf")]),
         ],
         use_project_defaults_for_omitted=True,
     )
@@ -110,10 +110,10 @@ def complex_artifact_flow(training_data: FlyteFile[TypeVar("csv")], test_data: F
         flyte_task_name="Make Model Two",
         command="make_model_two.py",
         inputs=[
-            Input(name="training_data", type=FlyteFile[TypeVar("csv")], value=prepped_training_data)
+            Input(name="training_data", type=DominoFile[TypeVar("csv")], value=prepped_training_data)
         ],
         output_specs=[
-            Output(name="model", type=FlyteFile[TypeVar("pkl")]),
+            Output(name="model", type=DominoFile[TypeVar("pkl")]),
         ],
         use_project_defaults_for_omitted=True,
     )
@@ -121,11 +121,11 @@ def complex_artifact_flow(training_data: FlyteFile[TypeVar("csv")], test_data: F
         flyte_task_name="Classify Model Two",
         command="classify_model_two.py",
         inputs=[
-            Input(name="model", type=FlyteFile[TypeVar("pkl")], value=model_two),
-            Input(name="data_points", type=FlyteFile[TypeVar("csv")], value=test_data)
+            Input(name="model", type=DominoFile[TypeVar("pkl")], value=model_two),
+            Input(name="data_points", type=DominoFile[TypeVar("csv")], value=test_data)
         ],
         output_specs=[
-            Output(name="predictions", type=FlyteFile[TypeVar("csv")]),
+            Output(name="predictions", type=DominoFile[TypeVar("csv")]),
         ],
         use_project_defaults_for_omitted=True,
     )
@@ -133,11 +133,11 @@ def complex_artifact_flow(training_data: FlyteFile[TypeVar("csv")], test_data: F
         flyte_task_name="Accuracy Report Model Two",
         command="make_accuracy_report.py",
         inputs=[
-            Input(name="predictions", type=FlyteFile[TypeVar("csv")], value=model_two_predictions),
-            Input(name="labels", type=FlyteFile[TypeVar("csv")], value=test_labels),
+            Input(name="predictions", type=DominoFile[TypeVar("csv")], value=model_two_predictions),
+            Input(name="labels", type=DominoFile[TypeVar("csv")], value=test_labels),
         ],
         output_specs=[
-            Output(name="accuracy", type=FlyteFile[TypeVar("pdf")]),
+            Output(name="accuracy", type=DominoFile[TypeVar("pdf")]),
         ],
         use_project_defaults_for_omitted=True,
     )
@@ -146,13 +146,13 @@ def complex_artifact_flow(training_data: FlyteFile[TypeVar("csv")], test_data: F
         flyte_task_name="Make Model Three",
         command="make_model_three.py",
         inputs=[
-            Input(name="training_data", type=FlyteFile[TypeVar("csv")], value=prepped_training_data)
+            Input(name="training_data", type=DominoFile[TypeVar("csv")], value=prepped_training_data)
         ],
         output_specs=[
-            Output(name="model", type=FlyteFile[TypeVar("extensionfoobarbaz")]),
-            Output(name="model_meta_one", type=FlyteFile[TypeVar("pkl")]),
-            Output(name="model_meta_two", type=FlyteFile[TypeVar("pkl")]),
-            Output(name="model_meta_three", type=FlyteFile[TypeVar("pkl")]),
+            Output(name="model", type=DominoFile[TypeVar("extensionfoobarbaz")]),
+            Output(name="model_meta_one", type=DominoFile[TypeVar("pkl")]),
+            Output(name="model_meta_two", type=DominoFile[TypeVar("pkl")]),
+            Output(name="model_meta_three", type=DominoFile[TypeVar("pkl")]),
         ],
         use_project_defaults_for_omitted=True,
     )
@@ -160,14 +160,14 @@ def complex_artifact_flow(training_data: FlyteFile[TypeVar("csv")], test_data: F
         flyte_task_name="Classify Model Three",
         command="classify_model_three.py",
         inputs=[
-            Input(name="model", type=FlyteFile[TypeVar("extensionfoobarbaz")], value=model_three),
-            Input(name="model_meta_one", type=FlyteFile[TypeVar("pkl")], value=model_three_meta_one),
-            Input(name="model_meta_two", type=FlyteFile[TypeVar("pkl")], value=model_three_meta_two),
-            Input(name="model_meta_three", type=FlyteFile[TypeVar("pkl")], value=model_three_meta_three),
-            Input(name="data_points", type=FlyteFile[TypeVar("csv")], value=test_data)
+            Input(name="model", type=DominoFile[TypeVar("extensionfoobarbaz")], value=model_three),
+            Input(name="model_meta_one", type=DominoFile[TypeVar("pkl")], value=model_three_meta_one),
+            Input(name="model_meta_two", type=DominoFile[TypeVar("pkl")], value=model_three_meta_two),
+            Input(name="model_meta_three", type=DominoFile[TypeVar("pkl")], value=model_three_meta_three),
+            Input(name="data_points", type=DominoFile[TypeVar("csv")], value=test_data)
         ],
         output_specs=[
-            Output(name="predictions", type=FlyteFile[TypeVar("csv")]),
+            Output(name="predictions", type=DominoFile[TypeVar("csv")]),
         ],
         use_project_defaults_for_omitted=True,
     )
@@ -175,11 +175,11 @@ def complex_artifact_flow(training_data: FlyteFile[TypeVar("csv")], test_data: F
         flyte_task_name="Accuracy Report Model Three",
         command="make_accuracy_report.py",
         inputs=[
-            Input(name="predictions", type=FlyteFile[TypeVar("csv")], value=model_three_predictions),
-            Input(name="labels", type=FlyteFile[TypeVar("csv")], value=test_labels),
+            Input(name="predictions", type=DominoFile[TypeVar("csv")], value=model_three_predictions),
+            Input(name="labels", type=DominoFile[TypeVar("csv")], value=test_labels),
         ],
         output_specs=[
-            Output(name="accuracy", type=FlyteFile[TypeVar("pdf")]),
+            Output(name="accuracy", type=DominoFile[TypeVar("pdf")]),
         ],
         use_project_defaults_for_omitted=True,
     )

--- a/data.py
+++ b/data.py
@@ -7,7 +7,7 @@ rows = int(Path("/workflow/inputs/rows").read_text())
 cols = int(Path("/workflow/inputs/cols").read_text())
 
 # Write random output
-with open('/workflow/outputs/data', 'w', newline='') as csvfile:
+with open('/workflow/outputs/data.csv', 'w', newline='') as csvfile:
     random_writer = csv.writer(csvfile, delimiter=',', quoting=csv.QUOTE_MINIMAL)
 
     # produce a header with the right number of columns

--- a/generate_artifacts.py
+++ b/generate_artifacts.py
@@ -1,5 +1,4 @@
 from flytekit import workflow
-from flytekit.types.file import FlyteFile
 from flytekit.types.directory import FlyteDirectory
 from flytekitplugins.domino.task import DominoJobConfig, DominoJobTask, GitRef
 from flytekitplugins.domino.artifact import Artifact, DATA, MODEL, REPORT

--- a/generate_artifacts_2.py
+++ b/generate_artifacts_2.py
@@ -1,5 +1,5 @@
 from flytekit import workflow
-from flytekit.types.file import FlyteFile
+from flytekitplugins.domino.file import DominoFile
 from flytekit.types.directory import FlyteDirectory
 from flytekitplugins.domino.task import DominoJobConfig, DominoJobTask, GitRef
 from flytekitplugins.domino.artifact import Artifact, DATA, MODEL, REPORT
@@ -42,11 +42,11 @@ def generate_artifacts() -> final_outputs:
             'dict': Dict[str,int]
         },
         outputs={
-            'csv': FlyteFile[TypeVar("csv")],            
+            'csv': DominoFile[TypeVar("csv")],            
             'json': DataArtifact.File(name="data.json"),
             'png': ReportArtifact.File(name="report.png"),
             'jpeg': ReportArtifact.File(name="report.jpeg"),
-            'notebook': FlyteFile[TypeVar("ipynb")],
+            'notebook': DominoFile[TypeVar("ipynb")],
             'mlflow_model': FlyteDirectory
         },
         use_latest=True

--- a/generate_files.py
+++ b/generate_files.py
@@ -1,5 +1,5 @@
 from flytekit import workflow
-from flytekit.types.file import FlyteFile
+from flytekitplugins.domino.file import DominoFile
 from flytekit.types.directory import FlyteDirectory
 from flytekitplugins.domino.task import DominoJobConfig, DominoJobTask, GitRef
 from typing import TypeVar, Optional, List, Dict
@@ -14,7 +14,7 @@ def generate_types():
         domino_job_config=DominoJobConfig(MainRepoGitRef=GitRef(Type="head"),
                                           Command="python /mnt/code/scripts/generate-sce-types.py"),
         inputs={'sdtm_data_path': str},
-        outputs={'pdf':FlyteFile[TypeVar("pdf")], 'sas7bdat': FlyteFile[TypeVar("sas7bdat")]},
+        outputs={'pdf':DominoFile[TypeVar("pdf")], 'sas7bdat': DominoFile[TypeVar("sas7bdat")]},
         use_latest=True
     )
 
@@ -32,11 +32,11 @@ def generate_types():
             'dict': Dict[str,int]
         },
         outputs={
-            'csv': FlyteFile[TypeVar("csv")],
-            'json': FlyteFile[TypeVar("json")],
-            'png': FlyteFile[TypeVar("png")],
-            'jpeg': FlyteFile[TypeVar("jpeg")],
-            'notebook': FlyteFile[TypeVar("ipynb")],
+            'csv': DominoFile[TypeVar("csv")],
+            'json': DominoFile[TypeVar("json")],
+            'png': DominoFile[TypeVar("png")],
+            'jpeg': DominoFile[TypeVar("jpeg")],
+            'notebook': DominoFile[TypeVar("ipynb")],
             'mlflow_model': FlyteDirectory
         },
         use_latest=True
@@ -63,7 +63,7 @@ def generate_types_on_remote_hw_tier():
                                           HardwareTierId="small-k8s-remote"
                                           ),
         inputs={'sdtm_data_path': str},
-        outputs={'pdf':FlyteFile[TypeVar("pdf")], 'sas7bdat': FlyteFile[TypeVar("sas7bdat")]},
+        outputs={'pdf':DominoFile[TypeVar("pdf")], 'sas7bdat': DominoFile[TypeVar("sas7bdat")]},
         use_latest=True
     )
 
@@ -83,11 +83,11 @@ def generate_types_on_remote_hw_tier():
             'dict': Dict[str,int]
         },
         outputs={
-            'csv': FlyteFile[TypeVar("csv")],
-            'json': FlyteFile[TypeVar("json")],
-            'png': FlyteFile[TypeVar("png")],
-            'jpeg': FlyteFile[TypeVar("jpeg")],
-            'notebook': FlyteFile[TypeVar("ipynb")],
+            'csv': DominoFile[TypeVar("csv")],
+            'json': DominoFile[TypeVar("json")],
+            'png': DominoFile[TypeVar("png")],
+            'jpeg': DominoFile[TypeVar("jpeg")],
+            'notebook': DominoFile[TypeVar("ipynb")],
             'mlflow_model': FlyteDirectory
         },
         use_latest=True

--- a/model_artifact.py
+++ b/model_artifact.py
@@ -1,5 +1,5 @@
 from flytekit import workflow
-from flytekit.types.file import FlyteFile
+from flytekitplugins.domino.file import DominoFile
 from flytekitplugins.domino.task import DominoJobConfig, DominoJobTask
 from flytekitplugins.domino.artifact import Artifact, DATA, MODEL, REPORT
 from typing import TypeVar, NamedTuple
@@ -28,7 +28,7 @@ def training_workflow(data_path: str):
     training_job = DominoJobTask(
         name='Train model',
         domino_job_config=training_job_config,
-        inputs={'processed_data': FlyteFile[TypeVar("csv")]},
+        inputs={'processed_data': DominoFile[TypeVar("csv")]},
         outputs={'pt': ModelArtifact.File(name="model.pt")},
         use_latest=True
     )

--- a/node_artifact_workflow.py
+++ b/node_artifact_workflow.py
@@ -1,5 +1,5 @@
 from flytekit import workflow
-from flytekit.types.file import FlyteFile
+from flytekitplugins.domino.file import DominoFile
 from flytekitplugins.domino.task import DominoJobConfig, DominoJobTask
 from flytekitplugins.domino.artifact import Artifact, DATA, MODEL, REPORT
 from typing import TypeVar, NamedTuple
@@ -30,7 +30,7 @@ def clean_and_prep_data() -> final_outputs:
     clean = DominoJobTask(
         name='Clean raw data',
         domino_job_config=DominoJobConfig(Command='python clean.py'),
-        inputs={'data': FlyteFile[TypeVar('csv')]},
+        inputs={'data': DominoFile[TypeVar('csv')]},
         outputs={'data': DataArtifact.File(name='clean.csv')},
         use_latest=True
     )(data=raw.data)
@@ -39,10 +39,10 @@ def clean_and_prep_data() -> final_outputs:
     generate_report = DominoJobTask(
         name='Render data as an official report',
         domino_job_config=DominoJobConfig(Command='python report.py'),
-        inputs={'data': FlyteFile[TypeVar('csv')]},
+        inputs={'data': DominoFile[TypeVar('csv')]},
         outputs={
-            'html': FlyteFile[TypeVar('html')],
-            'graph': FlyteFile[TypeVar('png')]
+            'html': DominoFile[TypeVar('html')],
+            'graph': DominoFile[TypeVar('png')]
         },
         use_latest=True
     )(data=clean.data)

--- a/paths-wf.py
+++ b/paths-wf.py
@@ -1,0 +1,61 @@
+from flytekitplugins.domino.helpers import Input, Output, run_domino_job_task
+from flytekitplugins.domino.task import DominoJobConfig, DominoJobTask, GitRef, EnvironmentRevisionSpecification, EnvironmentRevisionType, DatasetSnapshot
+from flytekit import workflow
+from flytekitplugins.domino.file import DominoFile, DominoFileLegacy
+from flytekit.types.directory import FlyteDirectory
+from flytekit.types.file import FlyteFile
+from typing import TypeVar, NamedTuple
+
+final_outputs = NamedTuple("final_outputs", model=DominoFile)
+
+@workflow
+def training_workflow(data_path: str) -> final_outputs: 
+    """
+    Sample data preparation and training workflow
+    This workflow accepts a path to a CSV for some initial input and simulates
+    the processing of the data and usage of the processed data in a training job.
+    To run this workflow, execute the following line in the terminal
+    pyflyte run --remote paths-wf.py training_workflow --data_path /mnt/code/artifacts/data.csv
+    :param data_path: Path of the CSV file data
+    :return: The training results as a model
+    """
+
+    data_prep_results = run_domino_job_task(
+        flyte_task_name="Prepare data",
+        command="python /mnt/code/scripts/prep-data.py",
+        environment_name="Domino Core Environment",
+        # environment_name="Domino Standard Environment Py3.10 R4.4",
+        hardware_tier_name="Small",
+        inputs=[
+            Input(name="data_path", type=str, value=data_path)
+        ],
+        output_specs=[
+            Output(name="processed_data", type=DominoFile[TypeVar("csv")])
+        ],
+        use_project_defaults_for_omitted=True,
+        cache=True,
+        cache_version="1.0"
+    )
+
+    training_results = run_domino_job_task(
+        flyte_task_name="Train model",
+        command="python /mnt/code/scripts/train-model.py",
+        environment_name="Domino Core Environment",
+        # environment_name="Domino Standard Environment Py3.10 R4.4",
+        hardware_tier_name="Small",
+        inputs=[
+            Input(name="processed_data_domino_file", type=DominoFile[TypeVar("csv")], value=data_prep_results['processed_data']),
+            Input(name="processed_data_flyte_file", type=FlyteFile[TypeVar("csv")], value=data_prep_results['processed_data']),
+            Input(name="processed_data_domino_file_legacy", type=DominoFileLegacy[TypeVar("csv")], value=data_prep_results['processed_data']),
+            Input(name="epochs", type=int, value=10),
+            Input(name="batch_size", type=int, value=32)
+        ],
+        output_specs=[
+            Output(name="model", type=DominoFile)
+        ],
+        use_project_defaults_for_omitted=True,
+        cache=True,
+        cache_version="1.0"
+    )
+
+    return final_outputs(model=training_results['model'])

--- a/report.py
+++ b/report.py
@@ -2,7 +2,7 @@ import pandas
 import shutil
 
 # convert csv to HTML
-df = pandas.read_csv('/workflow/inputs/data', sep=',') 
+df = pandas.read_csv('/workflow/inputs/data.csv', sep=',') 
 df.to_html('/workflow/outputs/html') 
 
 # dummy graph

--- a/scripts/assert-paths.py
+++ b/scripts/assert-paths.py
@@ -1,0 +1,26 @@
+import os
+import pandas as pd
+from time import sleep
+
+# Read input data. Inputs are stored in a blob at /workflow/inputs/<NAME OF INPUT>.
+data_path_df = "/workflow/inputs/{}.csv".format("processed_data_domino_file") # DominoFile
+data_path_ff = "/workflow/inputs/{}".format("processed_data_flyte_file") # FlyteFile
+data_path_dfl = "/workflow/inputs/{}".format("processed_data_domino_file_legacy") # DominoFileLegacy
+data_path_dflcsv = "/workflow/inputs/{}.csv".format("processed_data_domino_file_legacy") # DominoFileLegacy
+df = pd.read_csv(data_path_df)
+ff = pd.read_csv(data_path_ff)
+dfl = pd.read_csv(data_path_dfl)
+dflcsv = pd.read_csv(data_path_dflcsv)
+
+assert len(df) > 0
+assert len(ff) > 0
+assert len(dfl) > 0
+assert len(dflcsv) > 0
+
+# Pretend like something is happening here to train the model
+print("Training the model")
+sleep(20)
+
+# Write output. Outputs must be written to /workflow/outputs/<NAME OF OUTPUT> for it to be tracked.
+named_output = "model"
+os.mkdir("/workflow/outputs/{}".format(named_output)) 

--- a/scripts/prep-data.py
+++ b/scripts/prep-data.py
@@ -22,5 +22,5 @@ print(df)
 
 # Write output. Outputs must be written to /workflow/outputs/<NAME OF OUTPUT> for it to be tracked.
 named_output = "processed_data"
-df.to_csv("/workflow/outputs/{}".format(named_output))
+df.to_csv("/workflow/outputs/{}.csv".format(named_output))
 

--- a/scripts/train-model.py
+++ b/scripts/train-model.py
@@ -6,7 +6,7 @@ from time import sleep
 # For file inputs, the blob is the file input itself. 
 # For primitive type inputs like strings, integer, booleans, etc, they are stored inside the blob and must be read in by opening the file.
 named_input = "processed_data"
-data_path = "/workflow/inputs/{}".format(named_input)
+data_path = "/workflow/inputs/{}.csv".format(named_input)
 df = pd.read_csv(data_path)
 
 # Pretend like something is happening here to train the model

--- a/test.py
+++ b/test.py
@@ -1,7 +1,6 @@
 from utils.flyte import DominoTask, Input, Output
 from flytekit import workflow, dynamic
 from flytekit.experimental import eager
-from flytekit.types.file import FlyteFile
 from flytekit.types.directory import FlyteDirectory
 from typing import TypeVar, Optional
 import pandas as pd

--- a/utils/flyte.py
+++ b/utils/flyte.py
@@ -1,6 +1,5 @@
 import os
 from typing import List
-from flytekit.types.file import FlyteFile
 from flytekitplugins.domino.task import DominoJobConfig, DominoJobTask, GitRef, EnvironmentRevisionSpecification, EnvironmentRevisionType, DatasetSnapshot
 from flytekit.loggers import logger
 from dataclasses import dataclass

--- a/workflow.py
+++ b/workflow.py
@@ -1,13 +1,13 @@
 # from utils.flyte import DominoTask, Input, Output
 from flytekit import workflow
-from flytekit.types.file import FlyteFile
+from flytekitplugins.domino.file import DominoFile
 from flytekit.types.directory import FlyteDirectory
 from flytekitplugins.domino.task import DominoJobConfig, DominoJobTask, GitRef
 from typing import TypeVar, Optional, List, Dict
 import pandas as pd
 
 @workflow
-def training_workflow(data_path: str) -> FlyteFile: 
+def training_workflow(data_path: str) -> DominoFile: 
     """
     Sample data preparation and training workflow
 
@@ -29,7 +29,7 @@ def training_workflow(data_path: str) -> FlyteFile:
         # environment="Data Prep Environment",
         # hardware_tier="Small",
         inputs={'data_path': str},
-        outputs={'processed_data': FlyteFile},
+        outputs={'processed_data': DominoFile},
         use_latest=True
     )
 
@@ -41,15 +41,15 @@ def training_workflow(data_path: str) -> FlyteFile:
                                           Command="python /mnt/code/scripts/train-model.py"),
         # environment="Training Environment",
         # hardware_tier="Medium",
-        inputs={'processed_data': FlyteFile, 'epochs': int, 'batch_size': int},
-        outputs={'model': FlyteFile},
+        inputs={'processed_data': DominoFile, 'epochs': int, 'batch_size': int},
+        outputs={'model': DominoFile},
         use_latest=True
     )
 
     return training_results(processed_data=processed_data, epochs = 10, batch_size = 32)
 
 @workflow
-def training_subworkflow(data_path: str) -> FlyteFile: 
+def training_subworkflow(data_path: str) -> DominoFile: 
 
     data_prep_results = DominoJobTask(
         name="Prepare data",
@@ -58,7 +58,7 @@ def training_subworkflow(data_path: str) -> FlyteFile:
         # environment="Data Prep Environment",
         # hardware_tier="Small",
         inputs={'data_path': str},
-        outputs={'processed_data': FlyteFile},
+        outputs={'processed_data': DominoFile},
         use_latest=True
     )
 
@@ -70,8 +70,8 @@ def training_subworkflow(data_path: str) -> FlyteFile:
                                           Command="python /mnt/code/scripts/train-model.py"),
         # environment="Training Environment",
         # hardware_tier="Medium",
-        inputs={'processed_data': FlyteFile, 'epochs': int, 'batch_size': int},
-        outputs={'model': FlyteFile},
+        inputs={'processed_data': DominoFile, 'epochs': int, 'batch_size': int},
+        outputs={'model': DominoFile},
         use_latest=True
     )
 
@@ -88,7 +88,7 @@ def generate_types():
         # environment="Domino Standard Environment Py3.9 R4.3",
         # hardware_tier="Small",
         inputs={'sdtm_data_path': str},
-        outputs={'pdf':FlyteFile[TypeVar("pdf")], 'sas7bdat': FlyteFile[TypeVar("sas7bdat")]},
+        outputs={'pdf':DominoFile[TypeVar("pdf")], 'sas7bdat': DominoFile[TypeVar("sas7bdat")]},
         use_latest=True
     )
 
@@ -106,11 +106,11 @@ def generate_types():
             'dict': Dict[str,int]
         },
         outputs={
-            'csv': FlyteFile[TypeVar("csv")],
-            'json': FlyteFile[TypeVar("json")],
-            'png': FlyteFile[TypeVar("csv")],
-            'jpeg': FlyteFile[TypeVar("jpeg")],
-            'notebook': FlyteFile[TypeVar("ipynb")],
+            'csv': DominoFile[TypeVar("csv")],
+            'json': DominoFile[TypeVar("json")],
+            'png': DominoFile[TypeVar("csv")],
+            'jpeg': DominoFile[TypeVar("jpeg")],
+            'notebook': DominoFile[TypeVar("ipynb")],
             'mlflow_model': FlyteDirectory
         },
         use_latest=True
@@ -128,7 +128,7 @@ def generate_types():
 
 # pyflyte run --remote workflow.py training_workflow --data_path /mnt/code/artifacts/data.csv
 @workflow
-def training_workflow_git(data_path: str) -> FlyteFile: 
+def training_workflow_git(data_path: str) -> DominoFile: 
     """
     Sample data preparation and training workflow
 
@@ -148,7 +148,7 @@ def training_workflow_git(data_path: str) -> FlyteFile:
         domino_job_config=DominoJobConfig(MainRepoGitRef=GitRef(Type="head"),
                                           Command="python /mnt/code/scripts/prep-data.py"),
         inputs={'data_path': str},
-        outputs={'processed_data': FlyteFile},
+        outputs={'processed_data': DominoFile},
         use_latest=True
     )
 
@@ -160,8 +160,8 @@ def training_workflow_git(data_path: str) -> FlyteFile:
                                           Command="python /mnt/code/scripts/train-model.py"),
         # environment="Training Environment",
         # hardware_tier="Medium",
-        inputs={'processed_data': FlyteFile, 'epochs': int, 'batch_size': int},
-        outputs={'model': FlyteFile},
+        inputs={'processed_data': DominoFile, 'epochs': int, 'batch_size': int},
+        outputs={'model': DominoFile},
         use_latest=True
     )
 
@@ -179,9 +179,9 @@ def training_workflow_nested(data_path: str):
                                           Command="sleep 100"),
         # environment="Training Environment",
         # hardware_tier="Medium",
-        inputs={'model': FlyteFile},
+        inputs={'model': DominoFile},
         use_latest=True
-            # Input(name="model", type=FlyteFile, value=model)
+            # Input(name="model", type=DominoFile, value=model)
     )
 
     return 


### PR DESCRIPTION
https://github.com/cerebrotech/internal-e2e-tests-service/pull/2794

Rough idea is that all instances of “FlyteFile” in our e2e tests should be replaced with “DominoFile”, which is the “right” way to use files from this point on (file extensions are supported).